### PR TITLE
feat: Tooltip added to objectives and the title in the main screen

### DIFF
--- a/onTrack/onTrack/Components/ObjectiveControl.xaml
+++ b/onTrack/onTrack/Components/ObjectiveControl.xaml
@@ -16,7 +16,7 @@
         <SolidColorBrush x:Key="TextBox.MouseOver.Border" Color="#FF7EB4EA"/>
         <SolidColorBrush x:Key="TextBox.Focus.Border" Color="#FF569DE5"/>
     </UserControl.Resources>
-    <StackPanel Orientation="Horizontal" x:Name="sp">
+    <StackPanel ToolTip="{Binding Title, ElementName=root}" Orientation="Horizontal" x:Name="sp">
         <TextBox ContextMenu="{x:Null}" BorderBrush="Transparent" x:Name="tb" CaretBrush="White" LostFocus="tb_LostFocus" Width="350" IsEnabled="False" FontSize="30" Background="Transparent" Foreground="White" Text="{Binding Title, ElementName=root, Mode=TwoWay}"></TextBox>
         <Label x:Name="current" Content="⬅️" FontSize="30" Foreground="White" MouseDown="current_MouseDown">
             <Validation.ErrorTemplate>

--- a/onTrack/onTrack/Views/TimerView.xaml
+++ b/onTrack/onTrack/Views/TimerView.xaml
@@ -80,6 +80,7 @@
                 Foreground="White"
                 TextAlignment="Center"
                 Text="{Binding CurrentTask.Task}"
+                ToolTip="{Binding CurrentTask.Task}"
                 TextChanged="objective_TextChanged"
                 BorderThickness="0"
                 CaretBrush="White"


### PR DESCRIPTION
Full description of objectives can now be viewed as long as it doesn't exceed the width of the screen.