### PR TITLE
feat: Notifications only appear when AFK for the specified duration

### DIFF
--- a/onTrack/onTrack/AFKTracker.cs
+++ b/onTrack/onTrack/AFKTracker.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace onTrack
+{
+    public class AFKTracker
+    {
+        [DllImport("user32.dll", SetLastError = false)]
+        private static extern bool GetLastInputInfo(ref Lastinputinfo plii);
+        private static readonly DateTime SystemStartup = DateTime.Now.AddMilliseconds(-Environment.TickCount);
+
+        public static bool EvaluateIsAFK(int maxIdleTime)
+        {
+            Trace.WriteLine($"Idle for: {IdleTime.TotalSeconds}/{maxIdleTime} Seconds");
+            return Math.Floor(IdleTime.TotalSeconds) > 0;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct Lastinputinfo
+        {
+            public uint cbSize;
+            public readonly int dwTime;
+        }
+
+        public static DateTime LastInput => SystemStartup.AddMilliseconds(LastInputTicks);
+
+        public static TimeSpan IdleTime => DateTime.Now.Subtract(LastInput);
+
+        private static int LastInputTicks
+        {
+            get
+            {
+                var lii = new Lastinputinfo { cbSize = (uint)Marshal.SizeOf(typeof(Lastinputinfo)) };
+                GetLastInputInfo(ref lii);
+                return lii.dwTime;
+            }
+        }
+    }
+}

--- a/onTrack/onTrack/Main.cs
+++ b/onTrack/onTrack/Main.cs
@@ -267,6 +267,10 @@ namespace onTrack
                 if (Counted <= Duration)
                 {
                     ExecuteCallbacks();
+                    if (!AFKTracker.EvaluateIsAFK((int)Duration))
+                    {
+                        Reset();
+                    }
                     return;
                 }
                 Timer.AutoReset = false;


### PR DESCRIPTION
This is a quick solution which ensures that users are not distracted by any notifications as long as they remain active by either moving the mouse or pressing keys.